### PR TITLE
create unique workspaces per generation

### DIFF
--- a/terraform-runner/build.sh
+++ b/terraform-runner/build.sh
@@ -12,7 +12,7 @@ DOCKER_REPO=${DOCKER_REPO:-"isaaguilar"}
 ## Build setup-runner
 ##
 export USER_UID=2000
-export DOCKER_IMAGE="$DOCKER_REPO/setup-runner-alphav4:1.0.0"
+export DOCKER_IMAGE="$DOCKER_REPO/setup-runner-alphav5:1.0.0"
 printf "\n\n----------------\nBuilding $DOCKER_IMAGE\n"
 
 envsubst < setup.Dockerfile > temp

--- a/terraform-runner/setup.sh
+++ b/terraform-runner/setup.sh
@@ -7,6 +7,9 @@ if stat "$TFO_SSH"/* >/dev/null 2>/dev/null; then
   chmod -R 0600 "$TFO_ROOT_PATH"/.ssh/*
 fi
 
+out="$TFO_ROOT_PATH"/generations/$TFO_GENERATION
+mkdir -p "$out"
+
 if [[ -d "$TFO_MAIN_MODULE" ]]; then
     rm -rf "$TFO_MAIN_MODULE"
 fi


### PR DESCRIPTION
Fixes #59 
The ServiceAccount name fix has been expanded to really mean unique resources per workflow run. This makes sense so that runs don't trample each other's workspace. This isn't a horrible issue because the concept of "interruptible" pods has been added earlier. This concept lets the controller know not to destroy the workspace until the pod that is running completes. 

Also fixed some bugs introduced in https://github.com/isaaguilar/terraform-operator/commit/4af468a46826dae951fc2ce045182548c872f9dd which actually prevented the correct usage of the "execution override" scripts. 